### PR TITLE
Fix detectDriver function to properly get Windows netsh command

### DIFF
--- a/.github/workflows/python_sdk_test.yml
+++ b/.github/workflows/python_sdk_test.yml
@@ -43,7 +43,7 @@ jobs:
                       ${{ runner.os }}-pip-
 
             - name: Install Bluez on Ubuntu
-              run: sudo apt install -y bluez
+              run: sudo apt-get update && sudo apt install -y bluez
               if: ${{ matrix.os == 'ubuntu-latest'}}
 
             - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,24 @@ jobs:
                   git config core.fileMode false
                   make version VERSION=${{ github.event.inputs.version }}
 
-            - name: Deploy to Github
+            - name: Create commit
               shell: bash
               run: |
                   git config core.fileMode false
                   git config user.name github-actions
                   git config user.email github-actions@github.com
                   git commit -am "Set version to  $(VERSION) from github actions"
-                  git push
+
+            - name: Push to protected branch
+              uses: CasperWA/push-protected@v2
+              with:
+                token: ${{ secrets.PUSH_TO_PROTECTED_BRANCH }}
+                branch: main
+                force: false
+                unprotect_reviews: true
+
+            - name: Create tag
+              shell: bash
+              run: |
                   git tag ${{ github.event.inputs.version }}
                   git push origin ${{ github.event.inputs.version }}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ make clean serve
 
 Github Pages serves the site from the `gh-pages` branch of this repo. Whenever the main branch is updated (such
 as via a Pull Request being merged),
-the "Jekyll Build and Deploy" [Github Actions](https://github.com/features/actions) workflow will automatically
+the "Jekyll Build and Deploy" [Github Actions](hhttps://github.com/gopro/OpenGoPro/actions/workflows/release.yml) workflow will automatically
 be triggered to build the site from `main` and update the `gh-pages` branch.
 
 > Note! This process should be invisible to the developer

--- a/demos/python/sdk_wireless_camera_control/open_gopro/wifi_controller.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/wifi_controller.py
@@ -110,7 +110,10 @@ class Wireless(WifiController):
         response = cmd("get-command netsh")
         if len(response) > 0 and "not found" not in response and "not recognized" not in response:
             return "netsh"
-
+        response = cmd("WHERE netsh")
+        if len(response) > 0 and "Could not find files" not in response:
+            return "netsh"
+        
         # try nmcli (Ubuntu 14.04)
         response = cmd("which nmcli")
         if len(response) > 0 and "not found" not in response:

--- a/docs/specs/ble.md
+++ b/docs/specs/ble.md
@@ -33,11 +33,13 @@ Below is a table of cameras that support GoPro's public BLE API:
       <td>ID</td>
       <td>Model</td>
       <td>Marketing Name</td>
+      <td>Minimal Firmware Version</td>
     </tr>
     <tr>
       <td>55</td>
       <td>HD9.01</td>
       <td>HERO9 Black</td>
+      <td><a href="https://gopro.com/en/us/update/hero9-black">v1.60</a></td>
     </tr>
   </tbody>
 </table>

--- a/docs/specs/wifi.md
+++ b/docs/specs/wifi.md
@@ -39,11 +39,13 @@ Below is a table of cameras that support GoPro's public REST API:
       <td>ID</td>
       <td>Model</td>
       <td>Marketing Name</td>
+      <td>Minimal Firmware Version</td>
     </tr>
     <tr>
       <td>55</td>
       <td>HD9.01</td>
       <td>HERO9 Black</td>
+      <td><a href="https://gopro.com/en/us/update/hero9-black">v1.60</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Hey guys, long time fan of the GoPro WiFi/BLE API!

Was trying to run the scripts on my Windows machine, but the gopro-photo script threw an exception:

`ValueError: invalid literal for int() with base 10: 'file'`

This is because it jumps over to the Linux commands. Fixed it so it properly recognizes the Windows `netsh` command. For whatever reason `python3.8` uses `cmd` and not `powershell` to execute commands, and `get-command` and `which` were throwing "not found" errors.

Edit: force-pushed a squash of 2 commits as per the contributing docs.

