### PR TITLE
corrected typo in help text in video.py

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/demos/video.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/demos/video.py
@@ -137,7 +137,7 @@ def parse_arguments() -> Tuple[str, Path, Path, float]:
         "-o",
         "--output",
         type=Path,
-        help="Where to write the video to. If not set, write to 'video.jpg'",
+        help="Where to write the video to. If not set, write to 'video.mp4'",
         default=Path("video.mp4"),
     )
     args = parser.parse_args()


### PR DESCRIPTION
When using the demo gopro-video noticed a typo in the help text. It says that the default file name would be video.jpg instead of video.mp4. The PR fixes this typo. 
