### PR TITLE
Fixed parse error in pip install.

### DIFF
--- a/demos/python/tutorial/setup.py
+++ b/demos/python/tutorial/setup.py
@@ -14,7 +14,7 @@ URL = "https://github.com/gopro/OpenGoPro"
 EMAIL = "gopro.com"
 AUTHOR = "GoPro"
 
-REQUIRED = ["bleak=0.12.1"]
+REQUIRED = ["bleak==0.12.1"]
 
 here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, "README.md"), encoding="utf-8") as f:


### PR DESCRIPTION
I fixed the following error in pip install.

```
> pip -v install -r requirements.txt
Using pip 21.2.4 from C:\Python39\lib\site-packages\pip (python 3.9)
Obtaining file:///C:/(HOMEDIR)/source/repos/OpenGoPro/demos/python/tutorial (from -r requirements.txt (line 1))
    Running command python setup.py egg_info
    error in open_gopro_python_tutorials setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Parse error at "'=0.12.1'": Expected stringEnd
```

thank you.