### PR TITLE
Note regarding video performance modes

### DIFF
--- a/docs/specs/ble.md
+++ b/docs/specs/ble.md
@@ -17,7 +17,7 @@ using the Get Version command upon connection %}
 -   New features:
     -   SD card rating check error status
     -   SD card write speed error status
-    -   Camera control status status
+    -   Camera control status
     -   Usb connected status
 -   Breaking changes:
     -   Video Digital Lens setting parameter changes:

--- a/docs/specs/ble_versions/ble_2_0.md
+++ b/docs/specs/ble_versions/ble_2_0.md
@@ -275,6 +275,10 @@ A preset is a logical wrapper around a specific camera flatmode and a collection
 The set of presets available to load at any moment depends on the value of certain camera settings, which are outlined in the table below.
 </p>
 
+<p>
+NOTE: 5.3K Tripod, 4K Tripod, Basic, Ultra Slow-Mo and Video Performance Mode capability are available on HERO10 Black v1.16 Firmware Update.
+</p>
+
 <table border="1">
   <tbody>
     <tr style="background-color: rgb(0,0,0); color: rgb(255,255,255);">

--- a/docs/specs/wifi_versions/wifi_2_0.md
+++ b/docs/specs/wifi_versions/wifi_2_0.md
@@ -149,6 +149,10 @@ A preset is a logical wrapper around a specific camera flatmode and a collection
 The set of presets available to load at any moment depends on the value of certain camera settings, which are outlined in the table below.
 </p>
 
+<p>
+NOTE: 5.3K Tripod, 4K Tripod, Basic, Ultra Slow-Mo and Video Performance Mode capability are available on HERO10 Black v1.16 Firmware Update.
+</p>
+
 <table border="1">
   <tbody>
     <tr style="background-color: rgb(0,0,0); color: rgb(255,255,255);">


### PR DESCRIPTION
Adds an explanation as to why video performance modes and the ability to toggle them might not be present if the camera's firmware is not up to date.
