### PR TITLE
Add endpoint for deleting media files

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/api/wifi_commands.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/api/wifi_commands.py
@@ -88,6 +88,15 @@ class WifiCommands:
             GoProResp: command status and media info as JSON
         """
 
+        self.delete_media = WifiGetJsonWithParams[str](communicator, "gopro/media/delete/file?path=100GOPRO/{}")
+        """Delete a file from the camera.
+
+        Args:
+            value (str): Media file to delete (eg: GOPR0001.MP4)
+
+        Returns:
+            GoProResp: command status as JSON
+        """
         self.get_media_list = WifiGetJsonNoParams(
             communicator, "gopro/media/list", lambda x, _: {"files": x["media"][0]["fs"]}  # type: ignore
         )

--- a/docs/specs/http_versions/http_2_0.md
+++ b/docs/specs/http_versions/http_2_0.md
@@ -1244,8 +1244,8 @@ Below is a table of commands that can be sent to the camera and how to send them
       <td>Delete File "100GOPRO/xxx.JPG"</td>
       <td>GET</td>
       <td>/gopro/media/delete/file?path=100GOPRO/XXX.JPG</td>
-      <td><span style="color:green">✔</span></td>
-      <td><span style="color:green">✔</span></td>
+      <td>\&gt;= v01.30.00</td>
+      <td>\&gt;= v01.70.00</td>
     </tr>
     <tr style="background-color: rgb(245,249,255);">
       <td>Open GoPro</td>

--- a/docs/specs/http_versions/http_2_0.md
+++ b/docs/specs/http_versions/http_2_0.md
@@ -1240,6 +1240,14 @@ Below is a table of commands that can be sent to the camera and how to send them
       <td><span style="color:green">✔</span></td>
     </tr>
     <tr style="background-color: rgb(245,249,255);">
+      <td>Media: Delete File</td>
+      <td>Delete File "100GOPRO/xxx.JPG"</td>
+      <td>GET</td>
+      <td>/gopro/media/delete/file?path=100GOPRO/XXX.JPG</td>
+      <td><span style="color:green">✔</span></td>
+      <td><span style="color:green">✔</span></td>
+    </tr>
+    <tr style="background-color: rgb(245,249,255);">
       <td>Open GoPro</td>
       <td>Get version</td>
       <td>GET</td>


### PR DESCRIPTION
Noticed the endpoint has been added to GoPro HERO10 Black v1.30 firmware and GoPro Hero9 Black v1.70 firmwares. Tested it and it works great!