### PR TITLE
Fix Retries in Python WiredGoPro

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/gopro_wired.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/gopro_wired.py
@@ -122,7 +122,7 @@ class WiredGoPro(GoProBase[WiredApi], GoProWiredInterface):
             FailedToFindDevice: could not auto-discover GoPro via mDNS # noqa: DAR402
         """
         if not self._serial:
-            for retry in range(retries):
+            for retry in range(retries + 1):
                 try:
                     self._serial = WiredGoPro._find_serial_via_mdns(timeout)
                     if self._serial:
@@ -130,7 +130,7 @@ class WiredGoPro(GoProBase[WiredApi], GoProWiredInterface):
                 except GpException.FailedToFindDevice as e:
                     if retry == retries:
                         raise e
-                    logger.warning(f"Failed to discover GoPro. Retrying #{retry}")
+                    logger.warning(f"Failed to discover GoPro. Retrying #{retry + 1}")
 
         self.http_command.wired_usb_control(control=Params.Toggle.ENABLE)
         # Find and configure API version


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Does this pull request reference an issue (i.e. bug or enhancement)? If not, you should probably create one. If it is a very simple / small change, this is not needed and just describe the issue below.
- [x] Make sure to link this pull request to the issue after the pull request is created.
- [ ] Anyone can review this but make sure to add at least one administrator (anyone who can be found under Reviewers)
- [x] Make sure to add necessary documentation (if appropriate)
- [ ] Once the pull request is created, ensure that the pre-merge checks all run succesfully.
- [ ] If you add a file that requires copyright updates, this will be automatically done via pre-merge checks and pushed to your branch.

### Description
This is a simple fix so that `GpException.FailedToFindDevice` is raised properly when a GoPro fails to be discovered. Originally, the for loop was actually retrying `retries - 1` times AND the exception would never be raised, because the for loop terminated before `retry` would equal `retries`.