### PR TITLE
Add WebcamResolution and WebcamFOV to Python Paramaters

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/api/http_commands.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/api/http_commands.py
@@ -317,14 +317,14 @@ class HttpCommands(HttpMessages[HttpMessage, CmdId]):
 
     @http_get_json_command(endpoint="gopro/webcam/start", arguments=["res", "fov"])
     def webcam_start(
-        self, *, resolution: Optional[Params.Resolution] = None, fov: Optional[Params.PhotoFOV] = None
+        self, *, resolution: Optional[Params.WebcamResolution] = None, fov: Optional[Params.VideoFOV] = None
     ) -> GoProResp:
         """Start the webcam.
 
         Args:
-            resolution (Optional[open_gopro.api.params.Resolution]): resolution to use. If not set,
+            resolution (Optional[open_gopro.api.params.WebcamResolution]): resolution to use. If not set,
                 camera default will be used.
-            fov (Optional[open_gopro.api.params.PhotoFOV]): field of view to use. If not set, camera
+            fov (Optional[open_gopro.api.params.VideoFOV]): field of view to use. If not set, camera
                 default will be used.
 
         Returns:

--- a/demos/python/sdk_wireless_camera_control/open_gopro/api/http_commands.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/api/http_commands.py
@@ -317,14 +317,14 @@ class HttpCommands(HttpMessages[HttpMessage, CmdId]):
 
     @http_get_json_command(endpoint="gopro/webcam/start", arguments=["res", "fov"])
     def webcam_start(
-        self, *, resolution: Optional[Params.WebcamResolution] = None, fov: Optional[Params.VideoFOV] = None
+        self, *, resolution: Optional[Params.WebcamResolution] = None, fov: Optional[Params.WebcamFOV] = None
     ) -> GoProResp:
         """Start the webcam.
 
         Args:
             resolution (Optional[open_gopro.api.params.WebcamResolution]): resolution to use. If not set,
                 camera default will be used.
-            fov (Optional[open_gopro.api.params.VideoFOV]): field of view to use. If not set, camera
+            fov (Optional[open_gopro.api.params.WebcamFOV]): field of view to use. If not set, camera
                 default will be used.
 
         Returns:

--- a/demos/python/sdk_wireless_camera_control/open_gopro/api/params.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/api/params.py
@@ -127,6 +127,13 @@ class Resolution(GoProEnum):
     RES_5_3_K = 100
 
 
+class WebcamResolution(GoProEnum):
+    NOT_APPLICABLE = 0
+    RES_480 = 4
+    RES_720 = 7
+    RES_1080 = 12
+
+
 class FPS(GoProEnum):
     FPS_240 = 0
     FPS_120 = 1

--- a/demos/python/sdk_wireless_camera_control/open_gopro/api/params.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/api/params.py
@@ -170,6 +170,13 @@ class VideoFOV(GoProEnum):
     LINEAR_HORIZON_LOCK = 10
 
 
+class WebcamFOV(GoProEnum):
+    WIDE = 0
+    NARROW = 2
+    SUPERVIEW = 3
+    LINEAR = 4
+
+
 class PhotoFOV(GoProEnum):
     NOT_APPLICABLE = 0
     HYPERVIEW = 9


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Does this pull request reference an issue (i.e. bug or enhancement)? If not, you should probably create one. If it is a very simple / small change, this is not needed and just describe the issue below.
- [ ] Make sure to link this pull request to the issue after the pull request is created.
- [ ] Anyone can review this but make sure to add at least one administrator (anyone who can be found under Reviewers)
- [ ] Make sure to add necessary documentation (if appropriate)
- [ ] Once the pull request is created, ensure that the pre-merge checks all run succesfully.
- [ ] If you add a file that requires copyright updates, this will be automatically done via pre-merge checks and pushed to your branch.

### Description
Originally, the HTTP command method `webcam_start` was typed as taking `Params.Resolution` and `Params.PhotoFOV`; however, we can see in the HTTP specification that the values for working with the webcam are different.
![image](https://user-images.githubusercontent.com/54745152/210414432-28293b55-450c-4b04-88bd-2e9d3f50be71.png)
The values for the resolution are completely different, so I added `Params.WebcamResolution`.
While `Params.VideoFOV` is a superset of the values that the webcam can take, and we could just type `webcam_start` as taking `Params.VideoFOV`, it would mislead developers to believe that the webcam can also take the other values of `Params.VideoFOV`. Therefore, I added `Params.WebcamFOV`.
