### PR TITLE
Python SDK - improve wifi SSID matching (#378)

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/wifi/adapters/wireless.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/wifi/adapters/wireless.py
@@ -299,10 +299,9 @@ class NmcliWireless(WifiController):
         discovered = False
         while not discovered and (time.time() - start) <= timeout:
             # Scan for network
-            response = cmd(f"{self.sudo} nmcli device wifi list")
+            response = cmd(f"{self.sudo} nmcli -f SSID device wifi list")
             for result in response.splitlines()[1:]:  # Skip title row
-                # Remove * in IN-USE column since it makes the SSID column non-determinant
-                if result.strip(" *").split()[1] == ssid:
+                if result.strip() == ssid.strip():
                     discovered = True
                     break
             if discovered:
@@ -457,10 +456,9 @@ class Nmcli0990Wireless(WifiController):
         while not discovered and (time.time() - start) <= timeout:
             # Scan for network
             cmd(f"{self.sudo} nmcli device wifi rescan")
-            response = cmd(f"{self.sudo} nmcli device wifi list")
+            response = cmd(f"{self.sudo} nmcli -f SSID device wifi list")
             for result in response.splitlines()[1:]:  # Skip title row
-                # Remove * in IN-USE column since it makes the SSID column non-determinant
-                if result.strip(" *").split()[1] == ssid:
+                if result.strip() == ssid.strip():
                     discovered = True
                     break
             if discovered:
@@ -693,8 +691,12 @@ class NetworksetupWireless(WifiController):
             response = cmd(
                 r"/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport --scan"
             )
-            for result in response.splitlines()[1:]:  # Skip title row
-                if result.split()[0] == ssid:
+            lines = response.splitlines()
+            ssid_end_index = lines[0].index("SSID") + 4 # Find where the SSID column ends
+
+            for result in lines[1:]:  # Skip title row
+                current_ssid = result[:ssid_end_index].strip()
+                if current_ssid == ssid.strip():
                     discovered = True
                     break
             if discovered:


### PR DESCRIPTION
- [x] Does this pull request reference an issue (i.e. bug or enhancement)? If not, you should probably create one. If it is a very simple / small change, this is not needed and just describe the issue below.
- [x] Make sure to link this pull request to the issue after the pull request is created.
- [ ] Anyone can review this but make sure to add at least one administrator (anyone who can be found under Reviewers)
- [x] Make sure to add necessary documentation (if appropriate)
- [ ] Once the pull request is created, ensure that the pre-merge checks all run succesfully.
- [ ] If you add a file that requires copyright updates, this will be automatically done via pre-merge checks and pushed to your branch.

### Description
Fixes #378 
Improves Wifi SSID matching when connecting to a GoPro to allow for spaces in the SSID.
Adding the "-f SSID" option to nmcli changes its output to only show the SSID column.
Regarding MacOS, airport formats its output in columns such that the ends of all SSIDs align with the end of the "SSID" column label, which can be (ab)used for parsing. I was able to find screenshots from as far back as 2012 which display this behaviour, and my current machine running MacOS 13.4.1 also behaves like this, though I can't say for certain that every version formats its output like this.