### PR TITLE
Expose "raw":"1" from the API in MediaList

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/models/media_list.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/models/media_list.py
@@ -119,6 +119,7 @@ class MediaItem(CustomBaseModel):
     low_res_video_size: Optional[str] = Field(alias="glrv", default=None)  #: Low resolution video size
     lrv_file_size: Optional[str] = Field(alias="ls", default=None)  #: Low resolution file size
     session_id: Optional[str] = Field(alias="id", default=None)  # Media list session identifier
+    raw: Optional[str] = Field(default=None)  #: 1 if photo has raw version, 0 (or omitted) otherwise
 
 
 class GroupedMediaItem(MediaItem):

--- a/demos/python/sdk_wireless_camera_control/tests/unit/test_models.py
+++ b/demos/python/sdk_wireless_camera_control/tests/unit/test_models.py
@@ -116,6 +116,7 @@ MEDIA_LIST: Final = {
                     "ls": "-1",
                     "s": "25086075",
                 },
+                {"n": "GOPR0039.JPG", "cre": "1724339068", "mod": "1724339068", "raw": "1", "s": "783927"},
             ],
         }
     ],
@@ -134,9 +135,10 @@ def test_media_list():
     media_list = MediaList(**MEDIA_LIST)
     assert media_list
     items = media_list.files
-    assert len(items) == 12
+    assert len(items) == 13
     assert len([item for item in items if isinstance(item, GroupedMediaItem)]) == 2
     assert media_list.files[0].filename == "100GOPRO/GX010001.MP4"
+    assert media_list.files[-1].raw == "1"
 
 
 VIDEO_METADATA: Final = {


### PR DESCRIPTION
Expose the raw flag on the media list (keeping it as a string value, and omitting it if the API response does not include it). This means you can list files and download the .gpr raws without needing to do a separate metadata request for each file.

Not sure if this is exactly the right way to do it, but by the time I'd modified my local version to add this thought I might as well see if it was useful upstream.

If this is a welcome addition I can update the changelog and docs if that's needed as well?



