### PR TITLE
fix type of resolution CLI flag

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/demos/gui/livestream.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/demos/gui/livestream.py
@@ -73,8 +73,12 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--min_bit", type=int, help="Minimum bitrate.", default=1000)
     parser.add_argument("--max_bit", type=int, help="Maximum bitrate.", default=1000)
     parser.add_argument("--start_bit", type=int, help="Starting bitrate.", default=1000)
-    parser.add_argument("--resolution", help="Resolution.", choices=list(proto.EnumWindowSize.values()), default=None)
-    parser.add_argument("--fov", help="Field of View.", choices=list(proto.EnumLens.values()), default=None)
+    parser.add_argument(
+        "--resolution", help="Resolution.", choices=list(proto.EnumWindowSize.values()), default=None, type=int  # type: ignore
+    )
+    parser.add_argument(
+        "--fov", help="Field of View.", choices=list(proto.EnumLens.values()), default=None, type=int  # type: ignore
+    )
     return add_cli_args_and_parse(parser, wifi=False)
 
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Does this pull request reference an issue (i.e. bug or enhancement)? If not, you should probably create one. If it is a very simple / small change, this is not needed and just describe the issue below.
- [ ] Make sure to link this pull request to the issue after the pull request is created.
- [ ] Anyone can review this but make sure to add at least one administrator (anyone who can be found under Reviewers)
- [ ] Make sure to add necessary documentation (if appropriate)
- [ ] Once the pull request is created, ensure that the pre-merge checks all run succesfully.
- [ ] If you add a file that requires copyright updates, this will be automatically done via pre-merge checks and pushed to your branch.

### Description
Without this, I am getting this error:
```
$ python3 livestream.py MySsid SuperSecurePa55word rtmp://192.168.1.235/test_stream --resolution 4
usage: livestream.py [-h] [--min_bit MIN_BIT] [--max_bit MAX_BIT] [--start_bit START_BIT] [--resolution {4,7,12}]
                     [--fov {0,4,3}] [--log LOG] [--identifier IDENTIFIER]
                     ssid password url
livestream.py: error: argument --resolution: invalid choice: '4' (choose from 4, 7, 12)
```