### PR TITLE
Fix COHN cert default value, useful for multiple camera

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/demos/gui/livestream.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/demos/gui/livestream.py
@@ -70,6 +70,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("ssid", type=str, help="WiFi SSID to connect to.")
     parser.add_argument("password", type=str, help="Password of WiFi SSID.")
     parser.add_argument("url", type=str, help="RTMP server URL to stream to.")
+    parser.add_argument("identifier", type=str, help="GoPro identifier.")
     parser.add_argument("--min_bit", type=int, help="Minimum bitrate.", default=1000)
     parser.add_argument("--max_bit", type=int, help="Maximum bitrate.", default=1000)
     parser.add_argument("--start_bit", type=int, help="Starting bitrate.", default=1000)

--- a/demos/python/sdk_wireless_camera_control/open_gopro/gopro_wireless.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/gopro_wireless.py
@@ -443,8 +443,10 @@ class WirelessGoPro(GoProBase[WirelessApi], GoProWirelessInterface):
             logger.info("Waiting for COHN to be connected")
             await self.ble_command.cohn_get_status(register=True)
             ip_address, password = await asyncio.wait_for(credentials.get(), timeout)
+            hardware_info = await self.ble_command.get_hardware_info()
+            serial_number = hardware_info.data.serial_number
             cert = (await self.ble_command.cohn_get_certificate()).data.cert
-            self._cohn = CohnInfo(ip_address, "gopro", password, cert)
+            self._cohn = CohnInfo(ip_address, "gopro", password, cert,f"cohn_{serial_number}.crt")
             logger.info(f"Using COHN Credentials: {self._cohn}")
             return True
         except TimeoutError:

--- a/demos/python/sdk_wireless_camera_control/open_gopro/models/general.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/models/general.py
@@ -70,7 +70,7 @@ class CohnInfo:
     username: str
     password: str
     certificate: str
-    cert_path: Path = Path("cohn.crt")
+    cert_path: Path 
 
     def __post_init__(self) -> None:
         token = b64encode(f"{self.username}:{self.password}".encode("utf-8")).decode("ascii")


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

I encounter an issue when attempting to connect multiple GoPros using COHN mode. Each connection to COHN mode consistently utilizes the same certificate name, resulting in the overwriting of the previously created cohn.crt file. To address this, I propose implementing a small fix that generates a certificate name based on the serial number of the GoPro camera. This modification will facilitate easier connectivity of multiple GoPro cameras in COHN mode.

🤙 Thank you!
