### PR TITLE
Python SDK: Make Cohn feature backwards compatible

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/api/ble_commands.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/api/ble_commands.py
@@ -49,7 +49,7 @@ from open_gopro.models.constants import (
     SettingId,
     StatusId,
 )
-from open_gopro.models.types import CameraState
+from open_gopro.models.types import CameraState, ProtobufId
 from open_gopro.parsers.bytes import (
     ConstructByteParserBuilder,
     DateTimeByteParserBuilder,
@@ -430,7 +430,7 @@ class BleCommands(BleMessages[BleMessage]):
         response_action_id=ActionId.GET_PRESET_STATUS_RSP,
         request_proto=proto.RequestGetPresetStatus,
         response_proto=proto.NotifyPresetStatus,
-        additional_matching_ids={ActionId.PRESET_MODIFIED_NOTIFICATION},
+        additional_matching_ids={ProtobufId(FeatureId.QUERY, ActionId.PRESET_MODIFIED_NOTIFICATION)},
     )
     async def get_preset_status(
         self,
@@ -559,7 +559,7 @@ class BleCommands(BleMessages[BleMessage]):
         response_action_id=ActionId.REQUEST_WIFI_CONNECT_RSP,
         request_proto=proto.RequestConnect,
         response_proto=proto.ResponseConnect,
-        additional_matching_ids={ActionId.REQUEST_WIFI_CONNECT_RSP},
+        additional_matching_ids={ProtobufId(FeatureId.NETWORK_MANAGEMENT, ActionId.REQUEST_WIFI_CONNECT_RSP)},
     )
     async def request_wifi_connect(self, *, ssid: str) -> GoProResp[proto.ResponseConnect]:
         """Request the camera to connect to a WiFi network that is already provisioned.
@@ -580,7 +580,7 @@ class BleCommands(BleMessages[BleMessage]):
         response_action_id=ActionId.REQUEST_WIFI_CONNECT_NEW_RSP,
         request_proto=proto.RequestConnectNew,
         response_proto=proto.ResponseConnectNew,
-        additional_matching_ids={ActionId.REQUEST_WIFI_CONNECT_NEW_RSP},
+        additional_matching_ids={ProtobufId(FeatureId.NETWORK_MANAGEMENT, ActionId.REQUEST_WIFI_CONNECT_NEW_RSP)},
     )
     async def request_wifi_connect_new(self, *, ssid: str, password: str) -> GoProResp[proto.ResponseConnectNew]:
         """Request the camera to connect to a WiFi network that is not already provisioned.
@@ -666,7 +666,7 @@ class BleCommands(BleMessages[BleMessage]):
         response_action_id=ActionId.LIVESTREAM_STATUS_RSP,
         request_proto=proto.RequestGetLiveStreamStatus,
         response_proto=proto.NotifyLiveStreamStatus,
-        additional_matching_ids={ActionId.LIVESTREAM_STATUS_NOTIF},
+        additional_matching_ids={ProtobufId(FeatureId.COMMAND, ActionId.LIVESTREAM_STATUS_NOTIF)},
     )
     async def register_livestream_status(
         self,
@@ -819,5 +819,5 @@ class BleAsyncResponses:
     def add_parsers(cls) -> None:
         """Add all of the defined asynchronous responses to the global parser map"""
         for response in cls.responses:
-            GlobalParsers.add(response.action_id, response.parser)
+            GlobalParsers.add(ProtobufId(response.feature_id, response.action_id), response.parser)
             GlobalParsers.add_feature_action_id_mapping(response.feature_id, response.action_id)

--- a/demos/python/sdk_wireless_camera_control/open_gopro/api/ble_commands.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/api/ble_commands.py
@@ -306,9 +306,7 @@ class BleCommands(BleMessages[BleMessage]):
     @ble_write_command(
         uuid=GoProUUID.CQ_COMMAND,
         cmd=CmdId.REBOOT,
-        rules=MessageRules(
-            fastpass_analyzer=lambda **_: True,
-        ),
+        rules=MessageRules(fastpass_analyzer=lambda **_: True),
     )
     async def reboot(self) -> GoProResp[None]:
         """Reboot the camera (approximating a battery pull)
@@ -694,6 +692,7 @@ class BleCommands(BleMessages[BleMessage]):
         response_action_id=ActionId.RELEASE_NETWORK_RSP,
         request_proto=proto.RequestReleaseNetwork,
         response_proto=proto.ResponseGeneric,
+        rules=MessageRules(fastpass_analyzer=lambda **_: True),
     )
     async def release_network(self) -> GoProResp[None]:
         """Disconnect the camera Wifi network in STA mode so that it returns to AP mode.

--- a/demos/python/sdk_wireless_camera_control/open_gopro/api/ble_commands.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/api/ble_commands.py
@@ -666,7 +666,7 @@ class BleCommands(BleMessages[BleMessage]):
         response_action_id=ActionId.LIVESTREAM_STATUS_RSP,
         request_proto=proto.RequestGetLiveStreamStatus,
         response_proto=proto.NotifyLiveStreamStatus,
-        additional_matching_ids={ProtobufId(FeatureId.COMMAND, ActionId.LIVESTREAM_STATUS_NOTIF)},
+        additional_matching_ids={ProtobufId(FeatureId.QUERY, ActionId.LIVESTREAM_STATUS_NOTIF)},
     )
     async def register_livestream_status(
         self,

--- a/demos/python/sdk_wireless_camera_control/open_gopro/api/builders.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/api/builders.py
@@ -367,6 +367,7 @@ def ble_proto_command(
     response_proto: type[Protobuf],
     parser: Parser | None = None,
     additional_matching_ids: set[ProtobufId | CmdId] | None = None,
+    rules: MessageRules = MessageRules(),
 ) -> Callable:
     """Decorator to build a BLE Protobuf command and wrapper to execute it
 
@@ -380,6 +381,7 @@ def ble_proto_command(
         parser (Parser | None): Response parser to transform received Protobuf bytes. Defaults to None.
         additional_matching_ids (set[ProtobufId | CmdId] | None): Other action ID's to share this parser. This is used,
             for example, if a notification shares the same ID as the synchronous response. Defaults to None.
+        rules (MessageRules): rules that describe sending / receiving the message. Defaults to MessageRules() (no rules).
 
     Returns:
         Callable: Generated method to perform command
@@ -397,7 +399,7 @@ def ble_proto_command(
 
     @wrapt.decorator
     async def wrapper(wrapped: Callable, instance: BleMessages, _: Any, kwargs: Any) -> GoProResp:
-        return await instance._communicator._send_ble_message(message, **(await wrapped(**kwargs) or kwargs))
+        return await instance._communicator._send_ble_message(message, rules, **(await wrapped(**kwargs) or kwargs))
 
     return wrapper
 

--- a/demos/python/sdk_wireless_camera_control/open_gopro/demos/gui/livestream.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/demos/gui/livestream.py
@@ -42,14 +42,18 @@ async def main(args: argparse.Namespace) -> None:
         )
         assert gopro.streaming.url
         console.print(
-            f"[yellow]Livestream to {gopro.streaming.url} is now streaming and should be available for viewing at."
+            f"[yellow]Livestream to {gopro.streaming.url} is now streaming and should be available for viewing."
         )
         await ainput("Press enter to stop livestreaming...\n")
 
+        console.print("[yellow]Stopping livestream...")
         await gopro.streaming.stop_active_stream()
 
         # TODO merge this into access point feature
+        console.print("[yellow]Disconnecting GoPro from network...")
         await gopro.ble_command.release_network()
+
+        console.print(" [yellow]Exiting...")
 
 
 def parse_arguments() -> argparse.Namespace:

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/access_point_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/access_point_feature.py
@@ -33,19 +33,10 @@ logger = logging.getLogger(__name__)
 
 class AccessPointFeature(BaseFeature):
     """Access Point (AP) feature abstraction"""
-
-    @property
-    def is_ready(self) -> bool:  # noqa: D102
-        # It's ready upon initialization
-        return True
-
     @property
     def is_supported(self) -> bool:  # noqa: D102
         # All Open GoPro cameras support access point
         return True
-
-    async def wait_for_ready(self) -> None:  # noqa: D102
-        return
 
     async def close(self) -> None:  # noqa: D102
         return

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/access_point_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/access_point_feature.py
@@ -37,6 +37,11 @@ class AccessPointFeature(BaseFeature):
         # It's ready upon initialization
         return True
 
+    @property
+    def is_supported(self) -> bool:  # noqa: D102
+        # All Open GoPro cameras support access point
+        return True
+
     async def wait_for_ready(self) -> None:  # noqa: D102
         return
 

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/access_point_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/access_point_feature.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 class AccessPointFeature(BaseFeature):
     """Access Point (AP) feature abstraction"""
+
     @property
     def is_supported(self) -> bool:  # noqa: D102
         # All Open GoPro cameras support access point

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/access_point_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/access_point_feature.py
@@ -14,6 +14,7 @@ from open_gopro.domain.gopro_observable import GoproObserverDistinctInitial
 from open_gopro.features.base_feature import BaseFeature
 from open_gopro.models import proto
 from open_gopro.models.constants import ActionId
+from open_gopro.models.constants.constants import FeatureId
 from open_gopro.models.proto import (
     EnumProvisioning,
     EnumResultGeneric,
@@ -25,6 +26,7 @@ from open_gopro.models.proto import (
     ResponseConnectNew,
     ResponseStartScanning,
 )
+from open_gopro.models.types import ProtobufId
 
 logger = logging.getLogger(__name__)
 
@@ -59,18 +61,20 @@ class AccessPointFeature(BaseFeature):
             Result[proto.ResponseGetApEntries, GoProError]: Discovered AP entries on success or error
         """
         # Wait to receive scanning success
-        logger.info("Scanning for Wifi networks")
+        logger.info("Scanning for Wifi networks...")
 
         async with GoproObserverDistinctInitial[ResponseStartScanning, NotifStartScanning](
             gopro=self._gopro,
-            update=ActionId.NOTIF_START_SCAN,
+            update=ProtobufId(FeatureId.NETWORK_MANAGEMENT, ActionId.NOTIF_START_SCAN),
             register_command=self._gopro.ble_command.scan_wifi_networks(),
         ) as observable, asyncio.timeout(timeout):
             if observable.initial_response.result != EnumResultGeneric.RESULT_SUCCESS:
                 return Result.from_failure(GoProError("Failed to start scanning."))
 
+            logger.info("Waiting for scanning to complete...")
             result = await observable.observe().first(lambda s: s.scanning_state == EnumScanning.SCANNING_SUCCESS)
             entries = await self._gopro.ble_command.get_ap_entries(scan_id=result.scan_id)
+            logger.info(f"Scan complete. Found {len(entries.data.entries)} networks.")
             return Result.from_value(entries.data)
 
     async def connect(
@@ -104,7 +108,7 @@ class AccessPointFeature(BaseFeature):
                         NotifProvisioningState,
                     ](
                         gopro=self._gopro,
-                        update=ActionId.NOTIF_PROVIS_STATE,
+                        update=ProtobufId(FeatureId.NETWORK_MANAGEMENT, ActionId.NOTIF_PROVIS_STATE),
                         register_command=command,
                     ) as observable:
                         if observable.initial_response.result != EnumResultGeneric.RESULT_SUCCESS:

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/base_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/base_feature.py
@@ -10,7 +10,6 @@ from typing import Any, Callable
 
 import wrapt
 
-from open_gopro.api.api import WirelessApi
 from open_gopro.gopro_base import GoProBase
 
 
@@ -55,24 +54,9 @@ class BaseFeature(ABC):
         loop (asyncio.AbstractEventLoop): asyncio loop to use for this feature
     """
 
-    def __init__(
-        self,
-        gopro: GoProBase[WirelessApi],
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
-        self._gopro = gopro
-        self._loop = loop
-
-    @property
-    @abstractmethod
-    def is_ready(self) -> bool:
-        """Is the feature ready to use?
-
-        No other methods (besides wait_for_ready) should be used until the feature is ready
-
-        Returns:
-            bool: True if ready, False otherwise
-        """
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop
+        self._gopro: GoProBase[Any]
 
     @property
     @abstractmethod
@@ -83,9 +67,26 @@ class BaseFeature(ABC):
             bool: True if ready, False otherwise
         """
 
-    @abstractmethod
-    async def wait_for_ready(self) -> None:
-        """Wait until the feature is ready to use"""
+    async def open(  # pylint: disable=unused-argument
+        self,
+        loop: asyncio.AbstractEventLoop,
+        gopro: GoProBase[Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Open the feature for use.
+
+        This should be called before using any other methods in the feature. It must be called for each
+        GoProBase instance that is used with the feature.
+
+        Args:
+            loop (asyncio.AbstractEventLoop): asyncio loop to use for this feature
+            gopro (GoProBase[Any]): camera to operate on
+            *args (Any): additional arguments for subclasses
+            **kwargs (Any): additional keyword arguments for subclasses
+        """
+        self._loop = loop
+        self._gopro = gopro
 
     @abstractmethod
     async def close(self) -> None:

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/base_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/base_feature.py
@@ -47,12 +47,7 @@ def require_supported(wrapped: Callable, instance: BaseFeature, args: Any, kwarg
 
 
 class BaseFeature(ABC):
-    """Base Feature definition / interface
-
-    Args:
-        gopro (GoProBase[WirelessApi]): camera to operate on
-        loop (asyncio.AbstractEventLoop): asyncio loop to use for this feature
-    """
+    """Base Feature definition / interface"""
 
     def __init__(self) -> None:
         self._loop: asyncio.AbstractEventLoop

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/base_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/base_feature.py
@@ -2,12 +2,49 @@
 # This copyright was auto-generated on Mon May 12 23:03:50 UTC 2025
 
 """Functionality common to all features."""
+from __future__ import annotations
 
 import asyncio
 from abc import ABC, abstractmethod
+from typing import Any, Callable
+
+import wrapt
 
 from open_gopro.api.api import WirelessApi
 from open_gopro.gopro_base import GoProBase
+
+
+@wrapt.decorator
+def require_supported(wrapped: Callable, instance: BaseFeature, args: Any, kwargs: Any) -> Any:
+    """Ensure the feature is supported before allowing access.
+
+    Args:
+        wrapped (Callable): The wrapped function or property
+        instance (BaseFeature): The class instance (or None if accessing a property getter)
+        args (Any): Positional arguments
+        kwargs (Any): Keyword arguments
+
+    Returns:
+        Any: Result of the wrapped function
+
+    Raises:
+        RuntimeError: If feature is not supported
+    """
+    # Handle the case where instance might be None (property access)
+    # In this case, the instance is actually the first argument in args
+    actual_instance = instance if instance is not None else args[0]
+
+    if not actual_instance.is_supported:
+        raise RuntimeError(f"{actual_instance.__class__.__name__} feature is not supported on this camera")
+
+    if instance is None:
+        # Property getter case - call it with the rest of args (skipping the first one which is the instance)
+        if len(args) > 1:
+            return wrapped(args[0], *args[1:], **kwargs)
+        return wrapped(args[0])
+
+    # Normal method call
+    return wrapped(*args, **kwargs)
 
 
 class BaseFeature(ABC):
@@ -32,6 +69,15 @@ class BaseFeature(ABC):
         """Is the feature ready to use?
 
         No other methods (besides wait_for_ready) should be used until the feature is ready
+
+        Returns:
+            bool: True if ready, False otherwise
+        """
+
+    @property
+    @abstractmethod
+    def is_supported(self) -> bool:
+        """Is the feature supported on the  current camera?
 
         Returns:
             bool: True if ready, False otherwise

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/cohn_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/cohn_feature.py
@@ -34,7 +34,7 @@ class CohnFeature(BaseFeature):
 
     def __init__(self, cohn_db: TinyDB) -> None:
         super().__init__()
-        self._gopro: GoProBase[Any] | None = None
+        self._gopro: GoProBase[Any] | None = None  # type: ignore # TODO fix this.
         self._db = CohnDb(cohn_db)
         self._ready_event: asyncio.Event
         self._status_observable: GoProObservable[NotifyCOHNStatus]
@@ -71,6 +71,7 @@ class CohnFeature(BaseFeature):
         logger.debug("COHN opened")
 
     async def wait_until_ready(self) -> None:
+        """Wait until COHN is ready (the first status is received)"""
         logger.debug("Waiting for COHN to be ready")
         await asyncio.wait_for(self._ready_event.wait(), 30)
 

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/cohn_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/cohn_feature.py
@@ -20,8 +20,10 @@ from open_gopro.features.base_feature import BaseFeature, require_supported
 from open_gopro.gopro_base import GoProBase
 from open_gopro.models import proto
 from open_gopro.models.constants import ActionId
+from open_gopro.models.constants.constants import FeatureId
 from open_gopro.models.general import CohnInfo
 from open_gopro.models.proto import EnumCOHNNetworkState, EnumCOHNStatus
+from open_gopro.models.types import ProtobufId
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +54,7 @@ class CohnFeature(BaseFeature):
         # TODO close this
         self._status_observable = GoProObservable(
             gopro=self._gopro,
-            update=ActionId.RESPONSE_GET_COHN_STATUS,
+            update=ProtobufId(FeatureId.QUERY, ActionId.RESPONSE_GET_COHN_STATUS),
             register_command=self._gopro.ble_command.cohn_get_status(register=True),
         ).on_start(lambda _: self._ready_event.set())
         self._status_task: asyncio.Task = asyncio.create_task(self._track_status())

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/streaming/livestream.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/streaming/livestream.py
@@ -16,12 +16,14 @@ from open_gopro.domain.observable import Observable
 from open_gopro.features.streaming.base_stream import StreamController, StreamType
 from open_gopro.gopro_base import GoProBase
 from open_gopro.models.constants import ActionId, Toggle
+from open_gopro.models.constants.constants import FeatureId
 from open_gopro.models.proto import (
     EnumLiveStreamStatus,
     EnumRegisterLiveStreamStatus,
     NotifyLiveStreamStatus,
 )
 from open_gopro.models.streaming import LivestreamOptions
+from open_gopro.models.types import ProtobufId
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +80,7 @@ class LiveStreamController(StreamController[LivestreamOptions]):
             unregister_command=self.gopro.ble_command.register_livestream_status(
                 unregister=[EnumRegisterLiveStreamStatus.REGISTER_LIVE_STREAM_STATUS_STATUS]
             ),
-            update=ActionId.LIVESTREAM_STATUS_NOTIF,
+            update=ProtobufId(FeatureId.QUERY, ActionId.LIVESTREAM_STATUS_NOTIF),
         ).start()
 
     @property

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/streaming/stream_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/streaming/stream_feature.py
@@ -60,7 +60,7 @@ class StreamFeature(BaseFeature):
         Returns:
             bool: True if a stream is active, False otherwise.
         """
-        return self._current is not None
+        return self._current is not None and self._current.status == StreamController.StreamStatus.STARTED
 
     @property
     def url(self) -> str | None:

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/streaming/stream_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/streaming/stream_feature.py
@@ -46,6 +46,11 @@ class StreamFeature(BaseFeature):
         self._current: StreamController | None = None
 
     @property
+    def is_supported(self) -> bool:  # noqa: D102
+        # Streaming is always supported
+        return True
+
+    @property
     def current_stream(self) -> StreamType | None:
         """Get the current stream type.
 

--- a/demos/python/sdk_wireless_camera_control/open_gopro/features/streaming/stream_feature.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/features/streaming/stream_feature.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from returns.result import ResultE
@@ -25,7 +24,6 @@ from open_gopro.features.streaming.webcam_stream import (
     WebcamStreamController,
     WebcamStreamOptions,
 )
-from open_gopro.gopro_base import GoProBase
 from open_gopro.models.types import StreamOptions
 
 logger = logging.getLogger(__name__)
@@ -37,12 +35,8 @@ class StreamFeature(BaseFeature):
     There can only ever be one stream open at a time.
     """
 
-    def __init__(
-        self,
-        gopro: GoProBase,
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
-        super().__init__(gopro, loop)
+    def __init__(self) -> None:
+        super().__init__()
         self._current: StreamController | None = None
 
     @property
@@ -132,14 +126,6 @@ class StreamFeature(BaseFeature):
             await self._current.stop()
 
         return ResultE.from_value(None)
-
-    @property
-    def is_ready(self) -> bool:  # noqa: D102
-        # Always ready. We'll track stream status when they are requested to be opened
-        return True
-
-    async def wait_for_ready(self, _: float = 60) -> None:  # noqa: D102
-        return
 
     async def close(self) -> None:  # noqa: D102
         await self.stop_active_stream()

--- a/demos/python/sdk_wireless_camera_control/open_gopro/gopro_base.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/gopro_base.py
@@ -398,7 +398,7 @@ class GoProBase(GoProHttp, Generic[ApiType]):
                 # Back off before retrying. TODO This appears to be needed on MacOS
                 await asyncio.sleep(2)
             except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.critical(f"Unexpected error: {repr(e)}")
+                logger.error(f"Unexpected error: {repr(e)}")
             logger.warning(f"Retrying #{retry} to send the command...")
         else:
             raise ResponseTimeout(GoProBase.HTTP_GET_RETRIES)
@@ -463,7 +463,7 @@ class GoProBase(GoProHttp, Generic[ApiType]):
                 # Back off before retrying. TODO This appears to be needed on MacOS
                 await asyncio.sleep(2)
             except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.critical(f"Unexpected error: {repr(e)}")
+                logger.error(f"Unexpected error: {repr(e)}")
             logger.warning(f"Retrying #{retry} to send the command...")
         else:
             raise ResponseTimeout(GoProBase.HTTP_GET_RETRIES)

--- a/demos/python/sdk_wireless_camera_control/open_gopro/gopro_wired.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/gopro_wired.py
@@ -85,23 +85,8 @@ class WiredGoPro(GoProBase[WiredApi], GoProWiredInterface):
         self._poll_period = kwargs.get("poll_period", 2)
         self._encoding = False
         self._busy = False
-        self._streaming: open_gopro.features.StreamFeature
+        self.streaming = open_gopro.features.StreamFeature()
         self._loop: asyncio.AbstractEventLoop
-
-    @property
-    def streaming(self) -> open_gopro.features.StreamFeature:
-        """The Streaming feature abstraction
-
-        Raises:
-            GoProNotOpened: Feature is not yet available because GoPro has not yet been opened
-
-        Returns:
-            open_gopro.features.StreamFeature: Streaming Feature
-        """
-        try:
-            return self._streaming
-        except AttributeError as e:
-            raise GoProNotOpened("") from e
 
     async def open(self, timeout: int = 10, retries: int = 1) -> None:
         """Connect to the Wired GoPro Client and prepare it for communication
@@ -135,7 +120,7 @@ class WiredGoPro(GoProBase[WiredApi], GoProWiredInterface):
             raise InvalidOpenGoProVersion(version)
         logger.info(f"Using Open GoPro API version {version}")
 
-        self._streaming = open_gopro.features.StreamFeature(self, self._loop)
+        await self.streaming.open(self._loop, self)
 
         # Wait for initial ready state
         await self._wait_for_state({StatusId.ENCODING: False, StatusId.BUSY: False})

--- a/demos/python/sdk_wireless_camera_control/open_gopro/gopro_wireless.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/gopro_wireless.py
@@ -53,7 +53,7 @@ from open_gopro.gopro_base import (
     enforce_message_rules,
 )
 from open_gopro.models import GoProResp
-from open_gopro.models.constants import ActionId, GoProUUID, StatusId
+from open_gopro.models.constants import GoProUUID, StatusId
 from open_gopro.models.constants.settings import SettingId
 from open_gopro.models.types import ProtobufId, ResponseType, UpdateCb, UpdateType
 from open_gopro.network.ble import BleakWrapperController, BleUUID
@@ -753,7 +753,7 @@ class WirelessGoPro(GoProBase[WirelessApi], GoProWirelessInterface):
         if response._is_push:
             for update_id, value in response.data.items():
                 await self._notify_listeners(update_id, value)
-        elif isinstance(response.identifier, ActionId):
+        elif isinstance(response.identifier, ProtobufId):
             await self._notify_listeners(response.identifier, response.data)
 
     def _notification_handler(self, handle: int, data: bytearray) -> None:
@@ -924,9 +924,9 @@ class WirelessGoPro(GoProBase[WirelessApi], GoProWirelessInterface):
     @property
     def _base_url(self) -> str:
         return (
-            f"https://{self.ip_address}:8080/"
+            f"https://{self.ip_address}/"
             if self._should_enable_cohn and self.cohn.credentials
-            else f"http://{self.ip_address}/"
+            else f"http://{self.ip_address}:8080/"
         )
 
     @property

--- a/demos/python/sdk_wireless_camera_control/open_gopro/gopro_wireless.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/gopro_wireless.py
@@ -9,7 +9,6 @@ import asyncio
 import enum
 import logging
 import queue
-from tkinter import E
 import traceback
 from collections import defaultdict
 from copy import deepcopy

--- a/demos/python/sdk_wireless_camera_control/open_gopro/models/constants/constants.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/models/constants/constants.py
@@ -120,7 +120,6 @@ class QueryCmdId(GoProIntEnum):
     SETTING_VAL_PUSH = 0x92
     STATUS_VAL_PUSH = 0x93
     SETTING_CAPABILITY_PUSH = 0xA2
-    PROTOBUF_QUERY = 0xF5
 
 
 class Toggle(GoProIntEnum):

--- a/demos/python/sdk_wireless_camera_control/open_gopro/models/types.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/models/types.py
@@ -49,7 +49,7 @@ CameraState: TypeAlias = dict[SettingId | StatusId, Any]
 JsonDict: TypeAlias = dict[str, Any]
 """Generic JSON dictionary"""
 
-UpdateType: TypeAlias = SettingId | StatusId | ActionId
+UpdateType: TypeAlias = SettingId | StatusId | ProtobufId
 """Identifier Type of an asynchronous update"""
 
 UpdateCb: TypeAlias = Callable[[UpdateType, Any], Coroutine[Any, Any, None]]

--- a/demos/python/sdk_wireless_camera_control/open_gopro/models/types.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/models/types.py
@@ -30,6 +30,9 @@ class ProtobufId:
     feature_id: FeatureId
     action_id: ActionId | None
 
+    def __str__(self) -> str:
+        return f"{self.feature_id}::{self.action_id}" if self.action_id else str(self.feature_id)
+
 
 ProducerType: TypeAlias = tuple[QueryCmdId, SettingId | StatusId]
 """Types that can be registered for."""

--- a/demos/python/sdk_wireless_camera_control/open_gopro/models/types.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/models/types.py
@@ -5,12 +5,14 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Callable, Coroutine, TypeAlias
 
 import construct
 from google.protobuf.message import Message
 
 from open_gopro.models.constants import ActionId, CmdId, QueryCmdId, SettingId, StatusId
+from open_gopro.models.constants.constants import FeatureId
 from open_gopro.models.streaming import (
     LivestreamOptions,
     PreviewStreamOptions,
@@ -20,13 +22,22 @@ from open_gopro.network.ble.services import BleUUID
 
 Protobuf: TypeAlias = Message
 
+
+@dataclass(frozen=True)
+class ProtobufId:
+    """Protobuf identifier with optional action ID"""
+
+    feature_id: FeatureId
+    action_id: ActionId | None
+
+
 ProducerType: TypeAlias = tuple[QueryCmdId, SettingId | StatusId]
 """Types that can be registered for."""
 
 CmdType: TypeAlias = CmdId | QueryCmdId | ActionId
 """Types that identify a command."""
 
-ResponseType: TypeAlias = CmdType | StatusId | SettingId | BleUUID | str | construct.Enum
+ResponseType: TypeAlias = CmdType | StatusId | SettingId | BleUUID | str | construct.Enum | ProtobufId
 """Types that are used to identify a response."""
 
 CameraState: TypeAlias = dict[SettingId | StatusId, Any]
@@ -41,7 +52,7 @@ UpdateType: TypeAlias = SettingId | StatusId | ActionId
 UpdateCb: TypeAlias = Callable[[UpdateType, Any], Coroutine[Any, Any, None]]
 """Callback definition for update handlers"""
 
-IdType: TypeAlias = SettingId | StatusId | ActionId | CmdId | BleUUID | str
+IdType: TypeAlias = SettingId | StatusId | ProtobufId | CmdId | BleUUID | str
 """Message Identifier Type"""
 
 StreamOptions: TypeAlias = WebcamStreamOptions | LivestreamOptions | PreviewStreamOptions

--- a/demos/python/sdk_wireless_camera_control/open_gopro/parsers/response.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/parsers/response.py
@@ -45,6 +45,7 @@ validResponseProtobufIds: Final[list[tuple[FeatureId, ActionId]]] = [
     (FeatureId.COMMAND, ActionId.RESPONSE_CLEAR_COHN_CERT),
     (FeatureId.COMMAND, ActionId.RESPONSE_CREATE_COHN_CERT),
     (FeatureId.COMMAND, ActionId.RESPONSE_COHN_SETTING),
+    (FeatureId.COMMAND, ActionId.RELEASE_NETWORK_RSP),
     (FeatureId.NETWORK_MANAGEMENT, ActionId.SCAN_WIFI_NETWORKS_RSP),
     (FeatureId.NETWORK_MANAGEMENT, ActionId.NOTIF_START_SCAN),
     (FeatureId.NETWORK_MANAGEMENT, ActionId.GET_AP_ENTRIES_RSP),

--- a/demos/python/sdk_wireless_camera_control/open_gopro/util/logger.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/util/logger.py
@@ -47,7 +47,7 @@ class Logger:
         self.modules: dict[str, int] = {
             "open_gopro.gopro_base": logging.DEBUG,
             "open_gopro.gopro_wired": logging.DEBUG,
-            "open_gopro.gopro_wireless": logging.DEBUG,
+            "open_gopro.gopro_wireless": logging.DEBUG,  # TRACE for concurrency debugging
             "open_gopro.api.builders": logging.DEBUG,
             "open_gopro.api.http_commands": logging.DEBUG,
             "open_gopro.api.ble_commands": logging.DEBUG,
@@ -60,8 +60,8 @@ class Logger:
             "open_gopro.parsers.general": logging.DEBUG,
             "open_gopro.network.wifi.adapters.wireless": logging.DEBUG,
             "open_gopro.network.wifi.mdns_scanner": logging.DEBUG,
-            "open_gopro.domain.observable": logging.DEBUG,
-            "open_gopro.domain.gopro_observable": logging.DEBUG,
+            "open_gopro.domain.observable": logging.DEBUG,  # TRACE for concurrency debugging
+            "open_gopro.domain.gopro_observable": logging.DEBUG,  # TRACE for observable debugging
             "open_gopro.models.response": logging.DEBUG,
             "open_gopro.models.network_scan_response": logging.DEBUG,
             "open_gopro.features.cohn_feature": logging.DEBUG,

--- a/demos/python/sdk_wireless_camera_control/open_gopro/util/logger.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/util/logger.py
@@ -56,6 +56,7 @@ class Logger:
             "open_gopro.network.ble.client": logging.DEBUG,
             "open_gopro.parsers.bytes": logging.DEBUG,
             "open_gopro.parsers.json": logging.DEBUG,
+            "open_gopro.parsers.response": logging.DEBUG,
             "open_gopro.parsers.general": logging.DEBUG,
             "open_gopro.network.wifi.adapters.wireless": logging.DEBUG,
             "open_gopro.network.wifi.mdns_scanner": logging.DEBUG,

--- a/demos/python/sdk_wireless_camera_control/tests/conftest.py
+++ b/demos/python/sdk_wireless_camera_control/tests/conftest.py
@@ -3,7 +3,6 @@
 
 # pylint: disable=redefined-outer-name
 
-import asyncio
 import logging
 import re
 from pathlib import Path
@@ -25,7 +24,6 @@ from open_gopro.network.ble.adapters.bleak_wrapper import BleakWrapperController
 from open_gopro.network.ble.services import CharProps
 from open_gopro.network.wifi import WifiClient
 from open_gopro.util.logger import set_logging_level, setup_logging
-from tests import versions
 from tests.mocks import (
     MockBleCommunicator,
     MockBleController,

--- a/demos/python/sdk_wireless_camera_control/tests/mocks.py
+++ b/demos/python/sdk_wireless_camera_control/tests/mocks.py
@@ -6,6 +6,7 @@ import asyncio
 import re
 from csv import Error
 from dataclasses import dataclass, field
+from operator import is_
 from pathlib import Path
 from typing import Any, Generic, Optional, Pattern, TypeVar
 
@@ -285,6 +286,10 @@ class MockFeature(BaseFeature):
 
     @property
     def is_ready(self) -> bool:
+        return True
+
+    @property
+    def is_supported(self) -> bool:
         return True
 
     async def close(self) -> None:

--- a/demos/python/sdk_wireless_camera_control/tests/unit/test_access_point_feature.py
+++ b/demos/python/sdk_wireless_camera_control/tests/unit/test_access_point_feature.py
@@ -2,45 +2,196 @@
 # This copyright was auto-generated on Mon May 12 23:03:50 UTC 2025
 
 import asyncio
-from pathlib import Path
+from typing import Any
 
-import pytest
 import pytest_asyncio
 from returns.pipeline import is_successful
+from returns.result import Result
 
+import open_gopro.features
+from open_gopro.domain.exceptions import GoProError
 from open_gopro.features.access_point_feature import AccessPointFeature
 from open_gopro.gopro_wireless import WirelessGoPro
-from open_gopro.models.general import CohnInfo
-from open_gopro.models.proto.cohn_pb2 import (
-    EnumCOHNNetworkState,
-    EnumCOHNStatus,
-    NotifyCOHNStatus,
-)
-from open_gopro.models.proto.network_management_pb2 import (
+from open_gopro.models.proto import (
+    EnumProvisioning,
+    EnumResultGeneric,
+    EnumScanEntryFlags,
+    EnumScanning,
+    NotifProvisioningState,
     NotifStartScanning,
+    ResponseConnect,
+    ResponseConnectNew,
+    ResponseGetApEntries,
     ResponseStartScanning,
 )
-from open_gopro.models.proto.response_generic_pb2 import EnumResultGeneric
-
-provisioned_status = NotifyCOHNStatus(status=EnumCOHNStatus.COHN_PROVISIONED)
-unprovisioned_status = NotifyCOHNStatus(status=EnumCOHNStatus.COHN_UNPROVISIONED)
-connected_status = NotifyCOHNStatus(
-    status=EnumCOHNStatus.COHN_PROVISIONED,
-    state=EnumCOHNNetworkState.COHN_STATE_NetworkConnected,
-    ipaddress="ip",
-    username="user",
-    password="password",
-)
-cohn_credentials = CohnInfo(ip_address="ip", username="user", password="password", certificate="cert")
+from tests.mocks import MockGoproResp, MockObserver
 
 
 @pytest_asyncio.fixture(loop_scope="function")
 async def ap_feature(mock_wireless_gopro_basic: WirelessGoPro):
-    feature = AccessPointFeature(mock_wireless_gopro_basic, asyncio.get_running_loop())
+    feature = AccessPointFeature()
+    await feature.open(
+        gopro=mock_wireless_gopro_basic,
+        loop=asyncio.get_running_loop(),
+    )
     yield feature
     await feature.close()
 
 
-async def test_ap_feature_starts_successfully(ap_feature: AccessPointFeature):
-    await ap_feature.wait_for_ready()
-    assert ap_feature.is_ready
+def create_scan_entry(ssid: str, is_configured: bool = False) -> ResponseGetApEntries.ScanEntry:
+    """Helper to create scan entries for testing"""
+    flags = EnumScanEntryFlags.SCAN_FLAG_CONFIGURED if is_configured else 0
+    return ResponseGetApEntries.ScanEntry(
+        ssid=ssid,
+        scan_entry_flags=flags,
+    )
+
+
+async def test_ap_feature_is_supported(ap_feature: AccessPointFeature):
+    # AccessPointFeature is always supported
+    assert ap_feature.is_supported
+
+
+async def test_scan_wifi_networks_successful(ap_feature: AccessPointFeature, monkeypatch: Any):
+    # GIVEN
+    scan_entries = [
+        create_scan_entry("TestNetwork1"),
+        create_scan_entry("TestNetwork2", is_configured=True),
+    ]
+    # Mock BLE command response
+    scan_id = 12345
+
+    async def mock_scan_wifi_networks(*args: Any, **kwargs: Any) -> Any:
+        return MockGoproResp(value=ResponseStartScanning(result=EnumResultGeneric.RESULT_SUCCESS))
+
+    async def mock_get_ap_entries(*args: Any, **kwargs: Any) -> Any:
+        return MockGoproResp(value=ResponseGetApEntries(entries=scan_entries))
+
+    MockObserver.initial_response = ResponseStartScanning(result=EnumResultGeneric.RESULT_SUCCESS)
+    MockObserver.first_response = NotifStartScanning(
+        scanning_state=EnumScanning.SCANNING_SUCCESS,
+        scan_id=scan_id,
+    )
+
+    # Apply mocks
+    monkeypatch.setattr(ap_feature._gopro.ble_command, "scan_wifi_networks", mock_scan_wifi_networks)
+    monkeypatch.setattr(ap_feature._gopro.ble_command, "get_ap_entries", mock_get_ap_entries)
+    monkeypatch.setattr(open_gopro.features.access_point_feature, "GoproObserverDistinctInitial", MockObserver)
+
+    # WHEN
+    result = await ap_feature.scan_wifi_networks()
+
+    # THEN
+    assert is_successful(result)
+    networks = result.unwrap()
+    assert len(networks.entries) == 2
+    assert networks.entries[0].ssid == "TestNetwork1"
+    assert networks.entries[1].ssid == "TestNetwork2"
+    assert networks.entries[1].scan_entry_flags & EnumScanEntryFlags.SCAN_FLAG_CONFIGURED
+
+
+async def test_connect_to_configured_network(ap_feature: AccessPointFeature, monkeypatch: Any):
+    # GIVEN
+    test_ssid = "TestNetwork"
+    test_password = "password123"
+    scan_entries = [create_scan_entry(test_ssid, is_configured=True)]
+
+    # Setup mocks for scan_wifi_networks
+    async def mock_scan_wifi_networks(*args: Any, **kwargs: Any) -> Any:
+        return Result.from_value(ResponseGetApEntries(entries=scan_entries))
+
+    # Mock for request_wifi_connect
+    async def mock_request_wifi_connect(*args: Any, **kwargs: Any) -> Any:
+        return MockGoproResp(value=ResponseConnect(result=EnumResultGeneric.RESULT_SUCCESS))
+
+    MockObserver.initial_response = ResponseConnect(result=EnumResultGeneric.RESULT_SUCCESS)
+    MockObserver.first_response = NotifProvisioningState(
+        provisioning_state=EnumProvisioning.PROVISIONING_SUCCESS_NEW_AP
+    )
+
+    # Apply mocks
+    monkeypatch.setattr(ap_feature, "scan_wifi_networks", mock_scan_wifi_networks)
+    monkeypatch.setattr(ap_feature._gopro.ble_command, "request_wifi_connect", mock_request_wifi_connect)
+    monkeypatch.setattr(open_gopro.features.access_point_feature, "GoproObserverDistinctInitial", MockObserver)
+
+    # WHEN
+    result = await ap_feature.connect(test_ssid, test_password)
+
+    # THEN
+    assert is_successful(result)
+
+
+async def test_connect_to_new_network(ap_feature: AccessPointFeature, monkeypatch: Any):
+    # GIVEN
+    test_ssid = "NewNetwork"
+    test_password = "newpassword123"
+    scan_entries = [create_scan_entry(test_ssid, is_configured=False)]
+
+    # Setup mocks for scan_wifi_networks
+    async def mock_scan_wifi_networks(*args: Any, **kwargs: Any) -> Any:
+        from returns.result import Result
+
+        return Result.from_value(ResponseGetApEntries(entries=scan_entries))
+
+    # Mock for request_wifi_connect_new
+    async def mock_request_wifi_connect_new(*args: Any, **kwargs: Any) -> Any:
+        return ResponseConnectNew(result=EnumResultGeneric.RESULT_SUCCESS)
+
+    MockObserver.initial_response = ResponseConnectNew(result=EnumResultGeneric.RESULT_SUCCESS)
+    MockObserver.first_response = NotifProvisioningState(
+        provisioning_state=EnumProvisioning.PROVISIONING_SUCCESS_NEW_AP
+    )
+
+    # Apply mocks
+    monkeypatch.setattr(ap_feature, "scan_wifi_networks", mock_scan_wifi_networks)
+    monkeypatch.setattr(ap_feature._gopro.ble_command, "request_wifi_connect_new", mock_request_wifi_connect_new)
+    monkeypatch.setattr(open_gopro.features.access_point_feature, "GoproObserverDistinctInitial", MockObserver)
+
+    # WHEN
+    result = await ap_feature.connect(test_ssid, test_password)
+
+    # THEN
+    assert is_successful(result)
+
+
+async def test_connect_failure_network_not_found(ap_feature: AccessPointFeature, monkeypatch: Any):
+    # GIVEN
+    test_ssid = "NonexistentNetwork"
+    test_password = "password123"
+    scan_entries = [create_scan_entry("DifferentNetwork")]
+
+    # Setup mocks for scan_wifi_networks
+    async def mock_scan_wifi_networks(*args: Any, **kwargs: Any) -> Any:
+        from returns.result import Result
+
+        return Result.from_value(ResponseGetApEntries(entries=scan_entries))
+
+    # Apply mocks
+    monkeypatch.setattr(ap_feature, "scan_wifi_networks", mock_scan_wifi_networks)
+
+    # WHEN
+    result = await ap_feature.connect(test_ssid, test_password)
+
+    # THEN
+    assert not is_successful(result)
+    assert "Could not find SSID" in str(result.failure())
+
+
+async def test_connect_failure_scan_failed(ap_feature: AccessPointFeature, monkeypatch: Any):
+    # GIVEN
+    test_ssid = "TestNetwork"
+    test_password = "password123"
+
+    # Setup mocks for scan_wifi_networks to fail
+    async def mock_scan_wifi_networks_fail(*args: Any, **kwargs: Any) -> Any:
+        return Result.from_failure(GoProError("Scanning failed"))
+
+    # Apply mocks
+    monkeypatch.setattr(ap_feature, "scan_wifi_networks", mock_scan_wifi_networks_fail)
+
+    # WHEN
+    result = await ap_feature.connect(test_ssid, test_password)
+
+    # THEN
+    assert not is_successful(result)
+    assert "Scanning for SSID's failed" in str(result.failure())

--- a/demos/python/sdk_wireless_camera_control/tests/unit/test_ble_commands.py
+++ b/demos/python/sdk_wireless_camera_control/tests/unit/test_ble_commands.py
@@ -8,6 +8,7 @@ from construct import Int32ub
 from open_gopro.api.builders import BleSettingFacade
 from open_gopro.models import constants
 from open_gopro.models.constants import GoProUUID, SettingId
+from open_gopro.models.constants.constants import ErrorCode, FeatureId
 from tests.mocks import MockBleCommunicator, MockGoproResp
 
 

--- a/demos/python/sdk_wireless_camera_control/thirdPartyDependencies.csv
+++ b/demos/python/sdk_wireless_camera_control/thirdPartyDependencies.csv
@@ -11,9 +11,9 @@ markdown-it-py,3.0.0,326411,UNKNOWN,UNKNOWN,MIT LICENSE,True,0,markdown-it-py-3.
 mdurl,0.1.2,22532,UNKNOWN,UNKNOWN,MIT LICENSE,True,0,mdurl-0.1.2
 mypy,1.15.0,28075926,UNKNOWN,UNKNOWN,MIT LICENSE,True,0,mypy-1.15.0
 mypy-extensions,1.1.0,10152,UNKNOWN,UNKNOWN,,False,0,mypy-extensions-1.1.0
-packaging,24.2,233256,UNKNOWN,UNKNOWN,APACHE SOFTWARE LICENSE;; BSD LICENSE,True,0,packaging-24.2
+packaging,25.0,236496,UNKNOWN,UNKNOWN,APACHE SOFTWARE LICENSE;; BSD LICENSE,True,0,packaging-25.0
 pexpect,4.9.0,189532,https://pexpect.readthedocs.io/,Noah Spurrier; Thomas Kluyver; Jeff Quast,ISC LICENSE _ISCL_,True,0,pexpect-4.9.0
-protobuf,6.30.2,1607350,https://developers.google.com/protocol-buffers/,protobuf@googlegroups.com,3-CLAUSE BSD LICENSE,True,0,protobuf-6.30.2
+protobuf,6.31.0,1633246,https://developers.google.com/protocol-buffers/,protobuf@googlegroups.com,3-CLAUSE BSD LICENSE,True,0,protobuf-6.31.0
 ptyprocess,0.7.0,39299,https://github.com/pexpect/ptyprocess,Thomas Kluyver,ISC LICENSE _ISCL_,True,0,ptyprocess-0.7.0
 pydantic,2.11.4,1756910,UNKNOWN,UNKNOWN,MIT LICENSE,True,0,pydantic-2.11.4
 pydantic-core,2.33.2,5520457,https://github.com/pydantic/pydantic-core,UNKNOWN,MIT LICENSE,True,0,pydantic-core-2.33.2


### PR DESCRIPTION
## Pull Request Overview

This PR updates the SDK to support legacy COHN protobuf flows by introducing a unified `ProtobufId` identifier, adding support checks via a `require_supported` decorator, and enhancing the response parser and routing to handle unsupported protobuf responses gracefully.

- Introduce `ProtobufId` type and update all parsers/commands to use it
- Add `require_supported` decorator and `is_supported` checks for features
- Extend `BleRespBuilder` and `_route_response` to identify and route unsupported protobuf errors
- Update tests and mocks to cover new unsupported-CoHN behavior
- Bump third-party dependency versions and enable debug logging for response parsing

<details>
<summary>Show a summary per file</summary>

| File                                                                            | Description                                                     |
| ------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| demos/python/sdk_wireless_camera_control/thirdPartyDependencies.csv            | Bump `packaging` to 25.0 and `protobuf` to 6.31.0               |
| demos/python/sdk_wireless_camera_control/tests/unit/test_wireless_gopro.py      | Add unsupported protobuf operation test; update imports        |
| demos/python/sdk_wireless_camera_control/tests/unit/test_responses.py          | Add and adjust tests for unsupported protobuf responses         |
| demos/python/sdk_wireless_camera_control/tests/unit/test_ble_commands.py       | Import new `ErrorCode` and `FeatureId` for BLE command tests    |
| demos/python/sdk_wireless_camera_control/tests/mocks.py                        | Extend mocks for protobuf and remove legacy BLE send override   |
| demos/python/sdk_wireless_camera_control/open_gopro/util/logger.py             | Enable DEBUG logging for `open_gopro.parsers.response`          |
| demos/python/sdk_wireless_camera_control/open_gopro/parsers/response.py        | Add `validResponseProtobufIds` and handle missing action IDs    |
| demos/python/sdk_wireless_camera_control/open_gopro/models/types.py            | Introduce `ProtobufId` and update `ResponseType`                |
| demos/python/sdk_wireless_camera_control/open_gopro/models/constants/constants.py | Remove deprecated `PROTOBUF_QUERY` enum                         |
| demos/python/sdk_wireless_camera_control/open_gopro/gopro_wireless.py          | Enhance `_route_response` to match unsupported protobuf errors  |
| demos/python/sdk_wireless_camera_control/open_gopro/features/base_feature.py   | Implement `require_supported` decorator and `is_supported` abstract property |
| demos/python/sdk_wireless_camera_control/open_gopro/features/cohn_feature.py   | Add support tracking and guard methods with `require_supported` |
| demos/python/sdk_wireless_camera_control/open_gopro/features/streaming/stream_feature.py | Add `is_supported` property                                    |
| demos/python/sdk_wireless_camera_control/open_gopro/features/access_point_feature.py | Add `is_supported` property                                    |
| demos/python/sdk_wireless_camera_control/open_gopro/api/builders.py            | Update `BleProtoCommand` to use `ProtobufId`                    |
| demos/python/sdk_wireless_camera_control/open_gopro/api/ble_commands.py        | Update protobuf commands to use `ProtobufId` in `additional_matching_ids` |
</details>
