### PR TITLE
Improve OS X current-wifi determination

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/network/wifi/adapters/wireless.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/network/wifi/adapters/wireless.py
@@ -782,6 +782,9 @@ class NetworksetupWireless(WifiController):
     def current(self) -> tuple[str | None, SsidState]:
         """Get the currently connected SSID if there is one.
 
+        Raises:
+            RuntimeError: the current Wi-Fi network is redacted
+
         Returns:
             tuple[str | None, SsidState]: (SSID or None if not connected, SSID state)
         """


### PR DESCRIPTION
On OS X 14.7, I experienced an issue where attempting to connect would timeout. This turned out to be because `NetworksetupWireless.current()` was calling `ipconfig` to get the current SSID, even after a successful call to `networksetup`. `ipconfig` was returning `<redacted>`, overwriting the correct result from `networksetup`.

Happily, my problem was fixed by just skipping the `ipconfig` call (which seems like the original intention of this code, and a straightforward bug), but I've also added an explicit exception if a `<redacted>` value is returned, which will make the cause easier to diagnose if this happens for anyone else.

I'm not sure under which circumstances exactly these commands can return `<redacted>` values, but it seems like it's a privacy protection measure in recent OS X, which can be resolved by explicitly asking for location services permission.