### PR TITLE
Relax language requirements to "en_" instead of "en_US" for wifi driver

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/network/wifi/adapters/wireless.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/network/wifi/adapters/wireless.py
@@ -43,9 +43,9 @@ def ensure_us_english() -> None:
     else:
         language = os.environ["LANG"]
 
-    if not language.startswith("en_US"):
+    if not language.startswith("en_"):
         raise RuntimeError(
-            f"The Wifi driver parses CLI responses and only supports en_US where your language is {language}"
+            f"The Wifi driver parses CLI responses and only supports en_* where your language is {language}"
         )
 
 


### PR DESCRIPTION
### Description
When using any language other than en_US for `gopro-photo`, the error appears:
```
RuntimeError: The Wifi driver parses CLI responses and only supports en_US where your language is en_CA.UTF-8
```

Despite the fact that en_CA shouldn't cause any issues, as they're both basic english.

This change relaxes the strictness of the check, to be `en_*` instead of `en_US`. I used this issue #320 as a reference for fixing this.

If the issue is really that this NEEDS to be `en_US`, I have another potential fix that would force the output to be english, but this seemed simpler