### PR TITLE
Accept photos in jpg, 360 or 36p for tutorial 8 demos

### DIFF
--- a/demos/python/tutorial/tutorial_modules/tutorial_8_camera_media_list/wifi_media_download_file.py
+++ b/demos/python/tutorial/tutorial_modules/tutorial_8_camera_media_list/wifi_media_download_file.py
@@ -20,7 +20,7 @@ def main() -> None:
     # TODO update tutorial docs to get directory
     for media in media_list["media"]:
         for media_file in [x["n"] for x in media["fs"]]:
-            if media_file.lower().endswith(".jpg"):
+            if media_file.lower().endswith((".jpg", ".360", ".36p")):
                 logger.info(f"found a photo: {media_file}")
                 photo = media_file
                 directory = media["d"]

--- a/demos/python/tutorial/tutorial_modules/tutorial_8_camera_media_list/wifi_media_get_gpmf.py
+++ b/demos/python/tutorial/tutorial_modules/tutorial_8_camera_media_list/wifi_media_get_gpmf.py
@@ -20,7 +20,7 @@ def main() -> None:
     # TODO update tutorial docs to get directory
     for media in media_list["media"]:
         for media_file in [x["n"] for x in media["fs"]]:
-            if media_file.lower().endswith(".jpg"):
+            if media_file.lower().endswith((".jpg", ".360", ".36p")):
                 logger.info(f"found a photo: {media_file}")
                 photo = media_file
                 directory = media["d"]

--- a/demos/python/tutorial/tutorial_modules/tutorial_8_camera_media_list/wifi_media_get_screennail.py
+++ b/demos/python/tutorial/tutorial_modules/tutorial_8_camera_media_list/wifi_media_get_screennail.py
@@ -20,7 +20,7 @@ def main() -> None:
     # TODO update tutorial docs to get directory
     for media in media_list["media"]:
         for media_file in [x["n"] for x in media["fs"]]:
-            if media_file.lower().endswith(".jpg"):
+            if media_file.lower().endswith((".jpg", ".360", ".36p")):
                 logger.info(f"found a photo: {media_file}")
                 photo = media_file
                 directory = media["d"]

--- a/demos/python/tutorial/tutorial_modules/tutorial_8_camera_media_list/wifi_media_get_thumbnail.py
+++ b/demos/python/tutorial/tutorial_modules/tutorial_8_camera_media_list/wifi_media_get_thumbnail.py
@@ -20,7 +20,7 @@ def main() -> None:
     # TODO update tutorial docs to get directory
     for media in media_list["media"]:
         for media_file in [x["n"] for x in media["fs"]]:
-            if media_file.lower().endswith(".jpg"):
+            if media_file.lower().endswith((".jpg", ".360", ".36p")):
                 logger.info(f"found a photo: {media_file}")
                 photo = media_file
                 directory = media["d"]


### PR DESCRIPTION
### Description
When completing the tutorial 8, there is a bug where .360 and .36P files aren't viewed as valid images. Since the only thing checked for is .jpg files, my tests with the Max2 were failing.

This fixes that and allows files that are any of the formats listed above